### PR TITLE
Implement `IntoFuture` for `idb::OpenRequest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To use `idb`, you need to add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-idb = "0.1"
+idb = "0.2"
 ```
 
 ### Example
@@ -51,7 +51,7 @@ async fn create_database() -> Result<Database, Error> {
     });
 
     // `await` the future returned by `open_request.into_future()` (which returns the database instance)
-    open_request.into_future().await
+    open_request.await
 }
 ```
 

--- a/idb/Cargo.toml
+++ b/idb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idb"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Devashish Dixit <devashishdxt@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A futures based crate for interacting with IndexedDB on browsers using webassembly"

--- a/idb/src/lib.rs
+++ b/idb/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! idb = "0.1"
+//! idb = "0.2"
 //! ```
 //!
 //! ## Example
@@ -50,7 +50,7 @@
 //!     });
 //!
 //!     // `await` the future returned by `open_request.into_future()` (which returns the database instance)
-//!     open_request.into_future().await
+//!     open_request.await
 //! }
 //! ```
 //!

--- a/idb/src/utils.rs
+++ b/idb/src/utils.rs
@@ -81,7 +81,7 @@ pub async fn wait_transaction_abort(transaction: &mut Transaction) -> Result<(),
         .map_err(|_| Error::OneshotChannelReceiveError)
 }
 
-fn success_callback<T, E>(event: Event) -> Result<T, Error>
+pub fn success_callback<T, E>(event: Event) -> Result<T, Error>
 where
     T: TryFrom<JsValue, Error = E>,
     E: Into<Error>,
@@ -94,7 +94,7 @@ where
         .and_then(|js_value| TryInto::try_into(js_value).map_err(Into::into))
 }
 
-fn error_callback<T>(event: Event) -> Result<T, Error> {
+pub fn error_callback<T>(event: Event) -> Result<T, Error> {
     let request = StoreRequest::try_from(event.target().ok_or(Error::EventTargetNotFound)?)?;
 
     let error = request.error()?;

--- a/idb/tests/cursor.rs
+++ b/idb/tests/cursor.rs
@@ -29,7 +29,7 @@ async fn test_cursor_next_advance_and_get() {
             .unwrap();
     });
 
-    let database = open_request.into_future().await.unwrap();
+    let database = open_request.await.unwrap();
 
     // Insert multiple values
     let transaction = database
@@ -137,7 +137,7 @@ async fn test_cursor_delete() {
             .unwrap();
     });
 
-    let database = open_request.into_future().await.unwrap();
+    let database = open_request.await.unwrap();
 
     // Insert multiple values
     let transaction = database

--- a/idb/tests/database.rs
+++ b/idb/tests/database.rs
@@ -7,7 +7,7 @@ async fn test_database_name_and_version() {
     factory.delete("test").await.unwrap();
 
     let open_request = factory.open("test", 1).unwrap();
-    let database = open_request.into_future().await.unwrap();
+    let database = open_request.await.unwrap();
 
     assert_eq!(database.name(), "test");
     assert_eq!(database.version(), Ok(1));
@@ -36,7 +36,7 @@ async fn test_database_store_names() {
             .unwrap();
     });
 
-    let database = open_request.into_future().await.unwrap();
+    let database = open_request.await.unwrap();
 
     let store_names = database.store_names();
     assert_eq!(store_names.len(), 3);
@@ -68,7 +68,7 @@ async fn test_database_transaction() {
             .unwrap();
     });
 
-    let database = open_request.into_future().await.unwrap();
+    let database = open_request.await.unwrap();
 
     let read_transaction = database.transaction(&["store1"], TransactionMode::ReadOnly);
     assert!(
@@ -116,7 +116,7 @@ async fn test_database_delete_object_store() {
             .unwrap();
     });
 
-    let mut database = open_request.into_future().await.unwrap();
+    let mut database = open_request.await.unwrap();
     database.on_version_change(|database| database.close());
 
     let mut open_request = factory.open("test", 2).unwrap();
@@ -132,7 +132,7 @@ async fn test_database_delete_object_store() {
         database.delete_object_store("store2").unwrap();
     });
 
-    let database = open_request.into_future().await.unwrap();
+    let database = open_request.await.unwrap();
 
     let store_names = database.store_names();
     assert_eq!(store_names.len(), 2);

--- a/idb/tests/factory.rs
+++ b/idb/tests/factory.rs
@@ -22,7 +22,7 @@ async fn test_factory_open_delete() {
         open_request.unwrap_err()
     );
 
-    let database = open_request.unwrap().into_future().await;
+    let database = open_request.unwrap().await;
     assert!(
         database.is_ok(),
         "OpenRequest::into_future() should be Ok(): {}",

--- a/idb/tests/index.rs
+++ b/idb/tests/index.rs
@@ -30,7 +30,7 @@ async fn test_index_read() {
             .unwrap();
     });
 
-    let database = open_request.into_future().await.unwrap();
+    let database = open_request.await.unwrap();
 
     // Insert multiple values
     let transaction = database

--- a/idb/tests/object_store.rs
+++ b/idb/tests/object_store.rs
@@ -29,7 +29,7 @@ async fn test_object_store_metadata() {
             .unwrap();
     });
 
-    let database = open_request.into_future().await.unwrap();
+    let database = open_request.await.unwrap();
 
     let transaction = database
         .transaction(&["employees"], TransactionMode::ReadOnly)
@@ -80,7 +80,7 @@ async fn test_object_store_crud() {
             .unwrap();
     });
 
-    let database = open_request.into_future().await.unwrap();
+    let database = open_request.await.unwrap();
 
     // Add a value to store
     let transaction = database
@@ -332,7 +332,7 @@ async fn test_duplicate_add_fail() {
             .unwrap();
     });
 
-    let database = open_request.into_future().await.unwrap();
+    let database = open_request.await.unwrap();
 
     let transaction = database
         .transaction(&["employees"], TransactionMode::ReadWrite)

--- a/idb/tests/open_request.rs
+++ b/idb/tests/open_request.rs
@@ -14,7 +14,7 @@ async fn test_open_request_upgrade_needed() {
         sender.send(event).expect("channel send");
     });
 
-    let database = open_request.into_future().await.unwrap();
+    let database = open_request.await.unwrap();
 
     let event = receiver.await.unwrap();
 
@@ -31,7 +31,7 @@ async fn test_open_request_blocked() {
     factory.delete("test").await.unwrap();
 
     let open_request = factory.open("test", 1).unwrap();
-    let database = open_request.into_future().await.unwrap();
+    let database = open_request.await.unwrap();
 
     let mut blocking_open_request = factory.open("test", 2).unwrap();
 
@@ -47,7 +47,7 @@ async fn test_open_request_blocked() {
 
     database.close();
 
-    let database = blocking_open_request.into_future().await.unwrap();
+    let database = blocking_open_request.await.unwrap();
     assert_eq!(database.version(), Ok(2));
 
     database.close();

--- a/idb/tests/transaction.rs
+++ b/idb/tests/transaction.rs
@@ -15,7 +15,7 @@ async fn test_transaction_commit() {
             .unwrap();
     });
 
-    let database = open_request.into_future().await.unwrap();
+    let database = open_request.await.unwrap();
 
     let transaction = database
         .transaction(&["store1"], TransactionMode::ReadWrite)
@@ -77,7 +77,7 @@ async fn test_transaction_abort() {
             .unwrap();
     });
 
-    let database = open_request.into_future().await.unwrap();
+    let database = open_request.await.unwrap();
 
     let transaction = database
         .transaction(&["store1"], TransactionMode::ReadWrite)
@@ -127,7 +127,7 @@ async fn test_transaction_error() {
             .unwrap();
     });
 
-    let mut database = open_request.into_future().await.unwrap();
+    let mut database = open_request.await.unwrap();
     database.on_version_change(|database| {
         database.close();
     });
@@ -154,7 +154,7 @@ async fn test_transaction_error() {
             .unwrap();
     });
 
-    let database = open_request.into_future().await.unwrap();
+    let database = open_request.await.unwrap();
 
     let error = transaction.commit().await;
     assert!(error.is_err(), "commit should fail"); // Note that the value may still get committed to the store depending on indexedDB implementation on the browser


### PR DESCRIPTION
This PR can only be pushed once `IntoFuture` is stabilized.