### PR TITLE
Update Factory::open version param as optional

### DIFF
--- a/idb-sys/src/factory.rs
+++ b/idb-sys/src/factory.rs
@@ -24,11 +24,13 @@ impl Factory {
     /// with a lower version and there are open connections that don’t close in response to a `versionchange` event, the
     /// request will be blocked until they all close, then an upgrade will occur. If the database already exists with a
     /// higher version the request will fail.
-    pub fn open(&self, name: &str, version: u32) -> Result<DatabaseRequest, Error> {
-        self.inner
-            .open_with_u32(name, version)
-            .map(Into::into)
-            .map_err(Error::IndexedDbOpenFailed)
+    pub fn open(&self, name: &str, version: Option<u32>) -> Result<DatabaseRequest, Error> {
+        match version {
+            Some(version) => self.inner.open_with_u32(name, version),
+            None => self.inner.open(name),
+        }
+        .map(Into::into)
+        .map_err(Error::IndexedDbOpenFailed)
     }
 
     /// Attempts to delete the named database. If the database already exists and there are open connections that don’t

--- a/idb/src/factory.rs
+++ b/idb/src/factory.rs
@@ -20,7 +20,7 @@ impl Factory {
     /// with a lower version and there are open connections that don’t close in response to a `versionchange` event, the
     /// request will be blocked until they all close, then an upgrade will occur. If the database already exists with a
     /// higher version the request will fail.
-    pub fn open(&self, name: &str, version: u32) -> Result<OpenRequest, Error> {
+    pub fn open(&self, name: &str, version: Option<u32>) -> Result<OpenRequest, Error> {
         self.inner
             .open(name, version)
             .map(Into::into)

--- a/idb/tests/cursor.rs
+++ b/idb/tests/cursor.rs
@@ -9,7 +9,7 @@ async fn test_cursor_next_advance_and_get() {
     let factory = Factory::new().unwrap();
     factory.delete("test").await.unwrap();
 
-    let mut open_request = factory.open("test", 1).unwrap();
+    let mut open_request = factory.open("test", Some(1)).unwrap();
     open_request.on_upgrade_needed(|event| {
         let database = event.database().unwrap();
 
@@ -119,7 +119,7 @@ async fn test_cursor_delete() {
     let factory = Factory::new().unwrap();
     factory.delete("test").await.unwrap();
 
-    let mut open_request = factory.open("test", 1).unwrap();
+    let mut open_request = factory.open("test", Some(1)).unwrap();
     open_request.on_upgrade_needed(|event| {
         let database = event.database().unwrap();
 
@@ -219,7 +219,7 @@ async fn test_cursor_with_zero_matches() {
     let factory = Factory::new().unwrap();
     factory.delete("test").await.unwrap();
 
-    let mut open_request = factory.open("test", 1).unwrap();
+    let mut open_request = factory.open("test", Some(1)).unwrap();
     open_request.on_upgrade_needed(|event| {
         let database = event.database().unwrap();
 

--- a/idb/tests/database.rs
+++ b/idb/tests/database.rs
@@ -6,7 +6,7 @@ async fn test_database_name_and_version() {
     let factory = Factory::new().unwrap();
     factory.delete("test").await.unwrap();
 
-    let open_request = factory.open("test", 1).unwrap();
+    let open_request = factory.open("test", Some(1)).unwrap();
     let database = open_request.await.unwrap();
 
     assert_eq!(database.name(), "test");
@@ -21,7 +21,7 @@ async fn test_database_store_names() {
     let factory = Factory::new().unwrap();
     factory.delete("test").await.unwrap();
 
-    let mut open_request = factory.open("test", 1).unwrap();
+    let mut open_request = factory.open("test", Some(1)).unwrap();
     open_request.on_upgrade_needed(|event| {
         let database = event.database().unwrap();
 
@@ -53,7 +53,7 @@ async fn test_database_transaction() {
     let factory = Factory::new().unwrap();
     factory.delete("test").await.unwrap();
 
-    let mut open_request = factory.open("test", 1).unwrap();
+    let mut open_request = factory.open("test", Some(1)).unwrap();
     open_request.on_upgrade_needed(|event| {
         let database = event.database().unwrap();
 
@@ -101,7 +101,7 @@ async fn test_database_delete_object_store() {
     let factory = Factory::new().unwrap();
     factory.delete("test").await.unwrap();
 
-    let mut open_request = factory.open("test", 1).unwrap();
+    let mut open_request = factory.open("test", Some(1)).unwrap();
     open_request.on_upgrade_needed(|event| {
         let database = event.database().unwrap();
 
@@ -119,7 +119,7 @@ async fn test_database_delete_object_store() {
     let mut database = open_request.await.unwrap();
     database.on_version_change(|database| database.close());
 
-    let mut open_request = factory.open("test", 2).unwrap();
+    let mut open_request = factory.open("test", Some(2)).unwrap();
     open_request.on_upgrade_needed(|event| {
         let database = event.database().unwrap();
 

--- a/idb/tests/factory.rs
+++ b/idb/tests/factory.rs
@@ -15,7 +15,7 @@ fn test_factory_new() {
 async fn test_factory_open_delete() {
     let factory = Factory::new().unwrap();
 
-    let open_request = factory.open("test", 1);
+    let open_request = factory.open("test", None);
     assert!(
         open_request.is_ok(),
         "Factory::open() should be Ok(): {}",

--- a/idb/tests/index.rs
+++ b/idb/tests/index.rs
@@ -10,7 +10,7 @@ async fn test_index_read() {
     let factory = Factory::new().unwrap();
     factory.delete("test").await.unwrap();
 
-    let mut open_request = factory.open("test", 1).unwrap();
+    let mut open_request = factory.open("test", Some(1)).unwrap();
     open_request.on_upgrade_needed(|event| {
         let database = event.database().unwrap();
 

--- a/idb/tests/object_store.rs
+++ b/idb/tests/object_store.rs
@@ -9,7 +9,7 @@ async fn test_object_store_metadata() {
     let factory = Factory::new().unwrap();
     factory.delete("test").await.unwrap();
 
-    let mut open_request = factory.open("test", 1).unwrap();
+    let mut open_request = factory.open("test", Some(1)).unwrap();
     open_request.on_upgrade_needed(|event| {
         let database = event.database().unwrap();
 
@@ -60,7 +60,7 @@ async fn test_object_store_crud() {
     let factory = Factory::new().unwrap();
     factory.delete("test").await.unwrap();
 
-    let mut open_request = factory.open("test", 1).unwrap();
+    let mut open_request = factory.open("test", Some(1)).unwrap();
     open_request.on_upgrade_needed(|event| {
         let database = event.database().unwrap();
 
@@ -313,7 +313,7 @@ async fn test_duplicate_add_fail() {
     let factory = Factory::new().unwrap();
     factory.delete("test").await.unwrap();
 
-    let mut open_request = factory.open("test", 1).unwrap();
+    let mut open_request = factory.open("test", Some(1)).unwrap();
     open_request.on_upgrade_needed(|event| {
         let database = event.database().unwrap();
 

--- a/idb/tests/open_request.rs
+++ b/idb/tests/open_request.rs
@@ -7,7 +7,7 @@ async fn test_open_request_upgrade_needed() {
     let factory = Factory::new().unwrap();
     factory.delete("test").await.unwrap();
 
-    let mut open_request = factory.open("test", 1).unwrap();
+    let mut open_request = factory.open("test", Some(1)).unwrap();
 
     let (sender, receiver) = oneshot::channel();
     open_request.on_upgrade_needed(move |event| {
@@ -30,10 +30,10 @@ async fn test_open_request_blocked() {
     let factory = Factory::new().unwrap();
     factory.delete("test").await.unwrap();
 
-    let open_request = factory.open("test", 1).unwrap();
+    let open_request = factory.open("test", Some(1)).unwrap();
     let database = open_request.await.unwrap();
 
-    let mut blocking_open_request = factory.open("test", 2).unwrap();
+    let mut blocking_open_request = factory.open("test", Some(2)).unwrap();
 
     let (sender, receiver) = oneshot::channel();
     blocking_open_request.on_blocked(move |event| {

--- a/idb/tests/transaction.rs
+++ b/idb/tests/transaction.rs
@@ -6,7 +6,7 @@ async fn test_transaction_commit() {
     let factory = Factory::new().unwrap();
     factory.delete("test").await.unwrap();
 
-    let mut open_request = factory.open("test", 1).unwrap();
+    let mut open_request = factory.open("test", Some(1)).unwrap();
     open_request.on_upgrade_needed(|event| {
         let database = event.database().unwrap();
 
@@ -68,7 +68,7 @@ async fn test_transaction_abort() {
     let factory = Factory::new().unwrap();
     factory.delete("test").await.unwrap();
 
-    let mut open_request = factory.open("test", 1).unwrap();
+    let mut open_request = factory.open("test", Some(1)).unwrap();
     open_request.on_upgrade_needed(|event| {
         let database = event.database().unwrap();
 
@@ -118,7 +118,7 @@ async fn test_transaction_error() {
     let factory = Factory::new().unwrap();
     factory.delete("test").await.unwrap();
 
-    let mut open_request = factory.open("test", 1).unwrap();
+    let mut open_request = factory.open("test", Some(1)).unwrap();
     open_request.on_upgrade_needed(|event| {
         let database = event.database().unwrap();
 
@@ -145,7 +145,7 @@ async fn test_transaction_error() {
         .await
         .unwrap();
 
-    let mut open_request = factory.open("test", 2).unwrap();
+    let mut open_request = factory.open("test", Some(2)).unwrap();
     open_request.on_upgrade_needed(|event| {
         let database = event.database().unwrap();
 


### PR DESCRIPTION
Factory::open `version` param can be omitted.
Change `Factory::open` version param from `u32` to `Option<u32>`.

ref. https://developer.mozilla.org/en-US/docs/Web/API/IDBFactory/open