### PR TITLE
fix: Keep falsy JS values in success handler

### DIFF
--- a/idb/Cargo.toml
+++ b/idb/Cargo.toml
@@ -14,11 +14,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+futures = "0.3.26"
 idb-sys = { version = "0.2.0", path = "../idb-sys" }
 js-sys = "0.3.60"
 num-traits = "0.2.15"
 thiserror = "1.0.37"
-tokio = { version = "1.23.0", features = ["macros", "sync"] }
 wasm-bindgen = "0.2.83"
 web-sys = { version = "0.3.60", features = ["Event"] }
 

--- a/idb/src/cursor/key_cursor.rs
+++ b/idb/src/cursor/key_cursor.rs
@@ -119,10 +119,7 @@ impl KeyCursor {
         }
 
         let request = self.inner.update(value)?;
-        wait_request(request).await?.ok_or(Error::UnexpectedJsValue(
-            "value after update",
-            JsValue::NULL,
-        ))
+        wait_request(request).await
     }
 
     /// Delete the record pointed at by the cursor with a new value.
@@ -130,10 +127,8 @@ impl KeyCursor {
         if self.finished {
             return Err(Error::CursorFinished);
         }
-
         let request = self.inner.delete()?;
-        let _: Option<JsValue> = wait_request(request).await?;
-        Ok(())
+        wait_request(request).await.map(|_: JsValue| ())
     }
 }
 

--- a/idb/src/cursor/value_cursor.rs
+++ b/idb/src/cursor/value_cursor.rs
@@ -126,12 +126,8 @@ impl Cursor {
         if self.finished {
             return Err(Error::CursorFinished);
         }
-
         let request = self.inner.update(value)?;
-        wait_request(request).await?.ok_or(Error::UnexpectedJsValue(
-            "value after update",
-            JsValue::NULL,
-        ))
+        wait_request(request).await
     }
 
     /// Delete the record pointed at by the cursor with a new value.

--- a/idb/src/index.rs
+++ b/idb/src/index.rs
@@ -62,9 +62,7 @@ impl Index {
         limit: Option<u32>,
     ) -> Result<Vec<JsValue>, Error> {
         let request = self.inner.get_all(query.map(Into::into), limit)?;
-        let array = wait_request(request).await?;
-
-        Ok(array.map(array_to_vec).unwrap_or_default())
+        wait_request(request).await.map(array_to_vec)
     }
 
     /// Retrieves the keys of records matching the given key or key range in query (up to limit if given).
@@ -74,9 +72,7 @@ impl Index {
         limit: Option<u32>,
     ) -> Result<Vec<JsValue>, Error> {
         let request = self.inner.get_all_keys(query.map(Into::into), limit)?;
-        let array = wait_request(request).await?;
-
-        Ok(array.map(array_to_vec).unwrap_or_default())
+        wait_request(request).await.map(array_to_vec)
     }
 
     /// Retrieves the number of records matching the given key or key range in query.
@@ -99,7 +95,7 @@ impl Index {
         &self,
         query: Option<Query>,
         cursor_direction: Option<CursorDirection>,
-    ) -> Result<Option<Cursor>, Error> {
+    ) -> Result<Cursor, Error> {
         let request = self
             .inner
             .open_cursor(query.map(Into::into), cursor_direction)?;
@@ -112,7 +108,7 @@ impl Index {
         &self,
         query: Option<Query>,
         cursor_direction: Option<CursorDirection>,
-    ) -> Result<Option<KeyCursor>, Error> {
+    ) -> Result<KeyCursor, Error> {
         let request = self
             .inner
             .open_key_cursor(query.map(Into::into), cursor_direction)?;

--- a/idb/src/open_request.rs
+++ b/idb/src/open_request.rs
@@ -4,8 +4,8 @@ use std::{
     task::{Context, Poll},
 };
 
+use futures::channel::oneshot;
 use idb_sys::{DatabaseRequest, Request};
-use tokio::sync::oneshot;
 use wasm_bindgen::JsValue;
 use web_sys::EventTarget;
 

--- a/idb/src/open_request.rs
+++ b/idb/src/open_request.rs
@@ -118,9 +118,7 @@ impl IntoFuture for OpenRequest {
             let _ = error_sender.send(res);
         });
         self.inner.on_success(move |event| {
-            let res = success_callback(event).and_then(|optional: Option<Database>| {
-                optional.ok_or(Error::UnexpectedJsValue("database", JsValue::NULL))
-            });
+            let res = success_callback(event);
             let _ = success_sender.send(res);
         });
 

--- a/idb/src/utils.rs
+++ b/idb/src/utils.rs
@@ -1,6 +1,6 @@
+use futures::{channel::oneshot, select};
 use idb_sys::{Request, StoreRequest, Transaction as SysTransaction};
 use js_sys::Array;
-use tokio::{select, sync::oneshot};
 use wasm_bindgen::JsValue;
 use web_sys::Event;
 
@@ -11,8 +11,8 @@ where
     T: TryFrom<JsValue, Error = E> + 'static,
     E: Into<Error>,
 {
-    let (error_sender, error_receiver) = oneshot::channel::<Result<T, Error>>();
-    let (success_sender, success_receiver) = oneshot::channel::<Result<T, Error>>();
+    let (error_sender, mut error_receiver) = oneshot::channel::<Result<T, Error>>();
+    let (success_sender, mut success_receiver) = oneshot::channel::<Result<T, Error>>();
 
     request.on_error(move |event| {
         let res = error_callback(event);
@@ -30,8 +30,8 @@ where
 }
 
 pub async fn wait_transaction(transaction: &mut Transaction) -> Result<(), Error> {
-    let (error_sender, error_receiver) = oneshot::channel::<Result<(), Error>>();
-    let (success_sender, success_receiver) = oneshot::channel::<Result<(), Error>>();
+    let (error_sender, mut error_receiver) = oneshot::channel::<Result<(), Error>>();
+    let (success_sender, mut success_receiver) = oneshot::channel::<Result<(), Error>>();
 
     transaction.inner.on_error(move |event| {
         let res = transaction_error_callback(event);
@@ -48,8 +48,8 @@ pub async fn wait_transaction(transaction: &mut Transaction) -> Result<(), Error
 }
 
 pub async fn wait_transaction_commit(transaction: &mut Transaction) -> Result<(), Error> {
-    let (error_sender, error_receiver) = oneshot::channel::<Result<(), Error>>();
-    let (success_sender, success_receiver) = oneshot::channel::<Result<(), Error>>();
+    let (error_sender, mut error_receiver) = oneshot::channel::<Result<(), Error>>();
+    let (success_sender, mut success_receiver) = oneshot::channel::<Result<(), Error>>();
 
     transaction.inner.on_error(move |event| {
         let res = transaction_error_callback(event);

--- a/idb/src/utils.rs
+++ b/idb/src/utils.rs
@@ -81,6 +81,7 @@ pub async fn wait_transaction_abort(transaction: &mut Transaction) -> Result<(),
         .map_err(|_| Error::OneshotChannelReceiveError)
 }
 
+// TODO: return `T` instead of `Option<T>`.
 pub fn success_callback<T, E>(event: Event) -> Result<Option<T>, Error>
 where
     T: TryFrom<JsValue, Error = E>,
@@ -90,11 +91,7 @@ where
 
     let js_value = request.result()?;
 
-    if js_value.is_falsy() {
-        Ok(None)
-    } else {
-        TryInto::try_into(js_value).map(Some).map_err(Into::into)
-    }
+    TryInto::try_into(js_value).map(Some).map_err(Into::into)
 }
 
 pub fn error_callback<T>(event: Event) -> Result<T, Error> {


### PR DESCRIPTION
This is just a quick (untested) workaround and might lead to other problems.
As suggested in #12 I'd return `T` instead of `Option<T>` anyway.