### PR TITLE
fix: Fix re-opening the database with same index name

### DIFF
--- a/src/object_store/mod.rs
+++ b/src/object_store/mod.rs
@@ -267,7 +267,7 @@ impl ObjectStore {
     }
 
     /// Creates a new index in store with the given name, key path and options and returns a new [`Index`]. Returns an
-    /// [`Error`] if not called within an upgrade transaction.
+    /// [`Error`] if not called within an upgrade transaction or an index with the `name` already exists.
     pub fn create_index(
         &self,
         name: &str,


### PR DESCRIPTION
Hey thanks for all the good work on rust wasm ecosystem! 
We're using rexie and encountered following issue when porting our code to rexie 0.6 and traced it back here:
IndexedDB returns `ConstraintError` when trying to create index with name that already exists. Add check whether index name already exists and skip creating it or re-create it as necessary.