### PR TITLE
fix: Fix doc_lazy_continuation clippy lint introduced in 1.80

### DIFF
--- a/src/request/database/macros.rs
+++ b/src/request/database/macros.rs
@@ -31,7 +31,7 @@ macro_rules! impl_database_request {
             /// Release memory management of the callbacks to JS GC.
             ///
             /// > Note: This may leak memory. Read more about it
-            ///   [here](https://docs.rs/wasm-bindgen/latest/wasm_bindgen/closure/struct.Closure.html#method.into_js_value).
+            /// > [here](https://docs.rs/wasm-bindgen/latest/wasm_bindgen/closure/struct.Closure.html#method.into_js_value).
             pub fn forget_callbacks(&mut self) {
                 self.inner.forget_callbacks()
             }

--- a/src/request/database/mod.rs
+++ b/src/request/database/mod.rs
@@ -70,7 +70,7 @@ impl DatabaseRequest {
     /// Release memory management of the callbacks to JS GC.
     ///
     /// > Note: This may leak memory. Read more about it
-    ///   [here](https://docs.rs/wasm-bindgen/latest/wasm_bindgen/closure/struct.Closure.html#method.into_js_value).
+    /// > [here](https://docs.rs/wasm-bindgen/latest/wasm_bindgen/closure/struct.Closure.html#method.into_js_value).
     pub fn forget_callbacks(&mut self) {
         let success_callback = self.success_callback.take();
         let error_callback = self.error_callback.take();

--- a/src/request/store/macros.rs
+++ b/src/request/store/macros.rs
@@ -10,7 +10,7 @@ macro_rules! impl_store_request {
             /// Release memory management of the callbacks to JS GC.
             ///
             /// > Note: This may leak memory. Read more about it
-            ///   [here](https://docs.rs/wasm-bindgen/latest/wasm_bindgen/closure/struct.Closure.html#method.into_js_value).
+            /// > [here](https://docs.rs/wasm-bindgen/latest/wasm_bindgen/closure/struct.Closure.html#method.into_js_value).
             pub fn forget_callbacks(&mut self) {
                 self.inner.forget_callbacks();
             }

--- a/src/request/store/mod.rs
+++ b/src/request/store/mod.rs
@@ -30,7 +30,7 @@ impl StoreRequest {
     /// Release memory management of the callbacks to JS GC.
     ///
     /// > Note: This may leak memory. Read more about it
-    ///   [here](https://docs.rs/wasm-bindgen/latest/wasm_bindgen/closure/struct.Closure.html#method.into_js_value).
+    /// > [here](https://docs.rs/wasm-bindgen/latest/wasm_bindgen/closure/struct.Closure.html#method.into_js_value).
     pub fn forget_callbacks(&mut self) {
         let success_callback = self.success_callback.take();
         let error_callback = self.error_callback.take();

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -105,7 +105,7 @@ impl Transaction {
     /// Release memory management of the callbacks to JS GC.
     ///
     /// > Note: This may leak memory. Read more about it
-    ///   [here](https://docs.rs/wasm-bindgen/latest/wasm_bindgen/closure/struct.Closure.html#method.into_js_value).
+    /// > [here](https://docs.rs/wasm-bindgen/latest/wasm_bindgen/closure/struct.Closure.html#method.into_js_value).
     pub fn forget_callbacks(&mut self) {
         let abort_callback = self.abort_callback.take();
         let complete_callback = self.complete_callback.take();


### PR DESCRIPTION
Sorry for the PR spam, but this feels like an independent change.
Fix [doc_lazy_continuation](https://rust-lang.github.io/rust-clippy/master/index.html#/doc_lazy_continuation) lint introduced in 1.80, this should unblock builds in #23 and #24.