### PR TITLE
Fix request future drop panic by adding a drop implementation to forget all callbacks in request

### DIFF
--- a/src/cursor/key_cursor.rs
+++ b/src/cursor/key_cursor.rs
@@ -42,6 +42,8 @@ impl KeyCursor {
 
     /// Returns the [`OpenKeyCursorStoreRequest`] that was used to obtain this cursor.
     pub fn request(&self) -> OpenKeyCursorStoreRequest {
+        // This API was removed from idb 2.0 spec but will be added back in idb 3.0 spec
+        #[allow(deprecated)]
         self.inner.request().into()
     }
 

--- a/src/cursor/value_cursor.rs
+++ b/src/cursor/value_cursor.rs
@@ -46,6 +46,8 @@ impl Cursor {
 
     /// Returns the [`OpenCursorStoreRequest`] that was used to obtain this cursor.
     pub fn request(&self) -> OpenCursorStoreRequest {
+        // This API was removed from idb 2.0 spec but will be added back in idb 3.0 spec
+        #[allow(deprecated)]
         self.inner.request().into()
     }
 

--- a/src/index/index_params.rs
+++ b/src/index/index_params.rs
@@ -17,13 +17,13 @@ impl IndexParams {
 
     /// Sets the `unique` flag.
     pub fn unique(&mut self, unique: bool) -> &mut Self {
-        self.inner.unique(unique);
+        self.inner.set_unique(unique);
         self
     }
 
     /// Sets the `multi_entry` flag.
     pub fn multi_entry(&mut self, multi_entry: bool) -> &mut Self {
-        self.inner.multi_entry(multi_entry);
+        self.inner.set_multi_entry(multi_entry);
         self
     }
 }

--- a/src/object_store/object_store_params.rs
+++ b/src/object_store/object_store_params.rs
@@ -17,13 +17,15 @@ impl ObjectStoreParams {
 
     /// Sets the `auto_increment` flag.
     pub fn auto_increment(&mut self, auto_increment: bool) -> &mut Self {
-        self.inner.auto_increment(auto_increment);
+        self.inner.set_auto_increment(auto_increment);
         self
     }
 
     /// Sets the key path.
     pub fn key_path(&mut self, key_path: Option<KeyPath>) -> &mut Self {
-        self.inner.key_path(key_path.map(Into::into).as_ref());
+        if let Some(key_path) = key_path {
+            self.inner.set_key_path(&key_path.into());
+        }
         self
     }
 }

--- a/src/request/database/futures/macros.rs
+++ b/src/request/database/futures/macros.rs
@@ -3,7 +3,7 @@ macro_rules! impl_database_request_future {
         #[cfg_attr(any(docsrs, feature = "doc"), doc(cfg(feature = "futures")))]
         #[doc = $doc]
         pub struct $type {
-            _inner: $base_request,
+            inner: $base_request,
             success_receiver: tokio::sync::oneshot::Receiver<Result<$return_type, crate::Error>>,
             error_receiver: tokio::sync::oneshot::Receiver<crate::Error>,
         }
@@ -43,6 +43,12 @@ macro_rules! impl_database_request_future {
             }
         }
 
+        impl Drop for $type {
+            fn drop(&mut self) {
+                self.inner.forget_callbacks();
+            }
+        }
+
         #[cfg_attr(any(docsrs, feature = "doc"), doc(cfg(feature = "futures")))]
         impl std::future::IntoFuture for $base_request {
             type Output = <Self::IntoFuture as std::future::Future>::Output;
@@ -64,7 +70,7 @@ macro_rules! impl_database_request_future {
                 });
 
                 $type {
-                    _inner: self,
+                    inner: self,
                     success_receiver,
                     error_receiver,
                 }

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -59,6 +59,8 @@ impl Transaction {
     /// be accepted. This can be used to force a transaction to quickly finish, without waiting for pending requests to
     /// fire success events before attempting to commit normally.
     pub fn commit(self) -> Result<Self, Error> {
+        // This API was removed from idb 2.0 spec but will be added back in idb 3.0 spec
+        #[allow(deprecated)]
         self.inner.commit().map_err(Error::TransactionCommitError)?;
         Ok(self)
     }

--- a/tests/factory.rs
+++ b/tests/factory.rs
@@ -1,3 +1,5 @@
+use std::future::IntoFuture;
+
 use idb::Factory;
 use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -38,4 +40,34 @@ async fn test_factory_open_delete() {
         "Factory::delete() should be Ok(): {}",
         delete.unwrap_err()
     );
+}
+
+#[wasm_bindgen_test]
+async fn test_factory_open_request_drop() {
+    let factory = Factory::new().unwrap();
+
+    let open_request = factory.open("test", None);
+    assert!(
+        open_request.is_ok(),
+        "Factory::open() should be Ok(): {}",
+        open_request.unwrap_err()
+    );
+
+    let open_request = open_request.unwrap();
+    drop(open_request);
+}
+
+#[wasm_bindgen_test]
+async fn test_factory_open_request_future_drop() {
+    let factory = Factory::new().unwrap();
+
+    let open_request = factory.open("test", None);
+    assert!(
+        open_request.is_ok(),
+        "Factory::open() should be Ok(): {}",
+        open_request.unwrap_err()
+    );
+
+    let fut = open_request.unwrap().into_future();
+    drop(fut);
 }


### PR DESCRIPTION
Fixes #30 